### PR TITLE
Improve FFI docs and per-platform coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,24 @@ on:
   pull_request:
   merge_group:
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   stable-check:
     strategy:
       matrix:
-        os: 
-          - ubuntu-latest
-          - macos-latest
-          # - macos-13
-          - windows-latest
+        include:
+          - os: ubuntu-latest
+            coverage_flag: linux
+            coverage_file: coverage-linux.xml
+          - os: macos-latest
+            coverage_flag: macos
+            coverage_file: coverage-macos.xml
+          - os: windows-latest
+            coverage_flag: windows
+            coverage_file: coverage-windows.xml
       fail-fast: false
     runs-on: ${{ matrix.os }}
     continue-on-error: false
@@ -53,6 +62,25 @@ jobs:
       - name: run moon test
         run: |
           moon test --target all
+
+      - name: run native coverage test
+        run: |
+          moon test --target native --enable-coverage
+
+      - name: export native coverage report
+        run: |
+          moon coverage analyze -p justjavac/ffi -- -f cobertura -o "${{ matrix.coverage_file }}"
+
+      - name: upload coverage to Codecov
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          disable_search: true
+          files: ./${{ matrix.coverage_file }}
+          flags: ${{ matrix.coverage_flag }}
+          name: ${{ matrix.coverage_flag }}-native
+          verbose: true
 
       - name: moon build
         if: false

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ _build/
 target/
 .mooncakes/
 .DS_Store
+coverage-*.xml
+coverage.xml

--- a/README.mbt.md
+++ b/README.mbt.md
@@ -1,0 +1,22 @@
+# justjavac/ffi
+[![coverage](https://img.shields.io/codecov/c/github/justjavac/moonbit-ffi/main?label=coverage)](https://codecov.io/gh/justjavac/moonbit-ffi)
+[![linux](https://img.shields.io/codecov/c/github/justjavac/moonbit-ffi/main?flag=linux&label=linux)](https://codecov.io/gh/justjavac/moonbit-ffi)
+[![macos](https://img.shields.io/codecov/c/github/justjavac/moonbit-ffi/main?flag=macos&label=macos)](https://codecov.io/gh/justjavac/moonbit-ffi)
+[![windows](https://img.shields.io/codecov/c/github/justjavac/moonbit-ffi/main?flag=windows&label=windows)](https://codecov.io/gh/justjavac/moonbit-ffi)
+
+Helpers for converting MoonBit `String` values to and from null-terminated
+UTF-8 and UTF-16LE buffers at FFI boundaries.
+
+## Usage
+
+```moonbit check
+///|
+test {
+  let c_name = @ffi.to_cstr("ffi")
+  assert_eq(c_name, b"ffi\x00")
+  assert_eq(@ffi.from_cstr(c_name), "ffi")
+
+  let wide_name = @ffi.to_wstr("世界")
+  assert_eq(@ffi.from_wstr_lossy(wide_name), "世界")
+}
+```

--- a/README.md
+++ b/README.md
@@ -1,55 +1,105 @@
 # MoonBit FFI
+[![coverage](https://img.shields.io/codecov/c/github/justjavac/moonbit-ffi/main?label=coverage)](https://codecov.io/gh/justjavac/moonbit-ffi)
+[![linux](https://img.shields.io/codecov/c/github/justjavac/moonbit-ffi/main?flag=linux&label=linux)](https://codecov.io/gh/justjavac/moonbit-ffi)
+[![macos](https://img.shields.io/codecov/c/github/justjavac/moonbit-ffi/main?flag=macos&label=macos)](https://codecov.io/gh/justjavac/moonbit-ffi)
+[![windows](https://img.shields.io/codecov/c/github/justjavac/moonbit-ffi/main?flag=windows&label=windows)](https://codecov.io/gh/justjavac/moonbit-ffi)
 
-A lightweight utility library for converting between C‐style null-terminated
-byte strings (`Bytes`) and MoonBit `String` values.
+`justjavac/ffi` is a small MoonBit library for string-oriented FFI boundaries.
+It converts MoonBit `String` values to and from:
 
-[![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg)]()
+- C `char*`-style null-terminated UTF-8 byte buffers
+- Windows `wchar_t*`-style null-terminated UTF-16LE byte buffers
 
-## Features
+This README is the repository guide. Package consumers can use
+[`README.mbt.md`](./README.mbt.md) for the shorter package-facing version that is
+published with the module metadata.
 
-- **from_cstr**: Convert a null-terminated `Bytes` to a MoonBit `String` (drops
-  the `\x00` terminator).
-- **to_cstr**: Convert a MoonBit `String` to null-terminated `Bytes`.
+## Why This Repo Exists
+
+MoonBit already gives you low-level access to `Bytes`, but native APIs often want
+strings in ABI-specific layouts:
+
+- POSIX-style and many cross-platform libraries use null-terminated UTF-8 bytes
+- Win32 APIs commonly use null-terminated UTF-16 wide strings
+
+This package keeps those conversions in one place, with tests for the normal
+paths and failure paths.
+
+## Exported API
+
+- `@ffi.from_cstr(Bytes) -> String`
+  Converts a null-terminated UTF-8 buffer to a MoonBit string. It aborts when
+  the buffer does not end with `\x00`. Invalid UTF-8 sequences are decoded
+  lossily with replacement characters.
+- `@ffi.to_cstr(String) -> Bytes`
+  Encodes a MoonBit string as UTF-8 and appends a trailing `\x00`.
+- `@ffi.from_wstr_lossy(Bytes) -> String`
+  Decodes a null-terminated UTF-16LE buffer. It aborts when the input does not
+  end with `\x00\x00`.
+- `@ffi.to_wstr(String) -> Bytes`
+  Encodes a MoonBit string as UTF-16LE and appends a trailing wide null.
 
 ## Installation
-
-Add `justjavac/ffi` to your dependencies:
 
 ```shell
 moon update
 moon add justjavac/ffi
 ```
 
-## Usage
+## Quick Start
 
 ```moonbit
-// Convert Bytes → String
-let data = b"Hello, world!\x00"
-let s = @ffi.from_cstr(data)
-assert_eq!(s, "Hello, world!")
+let c_name = @ffi.to_cstr("hello.txt")
+let display_name = @ffi.from_cstr(c_name)
 
-// Convert String → Bytes
-let cstr = @ffi.to_cstr("Hello, world!")
-assert_eq!(cstr, data)
+let wide_title = @ffi.to_wstr("Hello, 世界")
+let title = @ffi.from_wstr_lossy(wide_title)
+
+assert_eq(display_name, "hello.txt")
+assert_eq(title, "Hello, 世界")
 ```
 
-## Supported Backends
+## Platform Notes
 
-- Wasm & WasmGC
-- JavaScript
-- Native
-- LLVM
+- `from_cstr` and `to_cstr` are appropriate for UTF-8 `char*` APIs on all
+  supported backends.
+- `from_wstr_lossy` and `to_wstr` are primarily for Windows APIs, but they are
+  deterministic and testable on any backend.
+- Missing terminators are treated as programmer errors and abort immediately.
+
+## Repository Layout
+
+- `README.md`: detailed repository overview
+- `README.mbt.md`: concise package documentation with tested examples
+- `src/cstr.mbt`: UTF-8 C string helpers
+- `src/wstr.mbt`: UTF-16 wide string helpers
+- `src/ffi_test.mbt`: black-box API and panic-path coverage tests
+- `.github/workflows/ci.yml`: multi-platform checks plus coverage upload
 
 ## Development
 
-Build the library and run tests (including docs):
+Run the normal validation loop from the repository root:
 
 ```shell
-moon build
-moon test --doc
+moon fmt
+moon check --target all --deny-warn
+moon test --target all
+moon test --target native --enable-coverage
+moon coverage analyze -p justjavac/ffi -- -f summary
 ```
+
+## Coverage Reporting
+
+CI keeps the existing Linux, macOS, and Windows matrix, then uploads a native
+coverage report for each platform to Codecov using platform flags:
+
+- `linux`
+- `macos`
+- `windows`
+
+The badges above update after the branch workflow finishes and Codecov finishes
+processing the uploads.
 
 ## License
 
-This project is licensed under the MIT License.\
-© justjavac
+MIT

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,34 @@
+codecov:
+  require_ci_to_pass: true
+  notify:
+    after_n_builds: 3
+    wait_for_ci: true
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+      linux:
+        flags:
+          - linux
+        target: auto
+      macos:
+        flags:
+          - macos
+        target: auto
+      windows:
+        flags:
+          - windows
+        target: auto
+
+flags:
+  linux:
+    paths:
+      - src/
+  macos:
+    paths:
+      - src/
+  windows:
+    paths:
+      - src/

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -2,12 +2,17 @@
   "name": "justjavac/ffi",
   "version": "0.2.0",
   "deps": {
-    "moonbitlang/x": "0.4.40"
+    "moonbitlang/x": "0.4.41"
   },
-  "readme": "README.md",
+  "readme": "README.mbt.md",
   "repository": "https://github.com/justjavac/moonbit-ffi",
   "license": "MIT",
-  "keywords": ["ffi", "bindings", "abi", "utils"],
+  "keywords": [
+    "ffi",
+    "bindings",
+    "abi",
+    "utils"
+  ],
   "description": "MoonBit Foreign Function Interface.",
   "source": "src"
 }

--- a/src/cstr.mbt
+++ b/src/cstr.mbt
@@ -1,182 +1,63 @@
 ///|
-/// # C-Style String Conversion Module
-/// 
-/// This module provides functions to convert between C-style null-terminated byte strings
-/// and MoonBit's `String` type. It is essential for FFI (Foreign Function Interface)
-/// operations where you need to pass strings to C functions or receive strings from C code.
-/// 
-/// ## Features
-/// 
-/// - **C string compatibility**: Handles null-terminated byte arrays as used by C
-/// - **Bidirectional conversion**: Convert from and to C-style strings
-/// - **Safety checks**: Validates null termination and proper formatting
-/// - **FFI integration**: Designed for seamless integration with FFI calls
-/// - **UTF-8 support**: Properly handles UTF-8 encoded text content
-/// 
-/// ## Basic Usage
-/// 
-/// ```moonbit
-/// // Convert MoonBit string to C-style null-terminated bytes
-/// let moonbit_str = "Hello, World!"
-/// let c_str_bytes = @ffi.to_cstr(moonbit_str)
-/// // c_str_bytes now contains: b"Hello, World!\x00"
-/// 
-/// // Convert C-style bytes back to MoonBit string
-/// let recovered_str = @ffi.from_cstr(c_str_bytes)
-/// // recovered_str equals "Hello, World!"
-/// 
-/// // Use with FFI functions that expect C strings
-/// // extern "C" fn c_function_that_takes_string(s : Bytes) -> Int = "my_c_function"
-/// // let result = c_function_that_takes_string(@ffi.to_cstr("Hello from MoonBit!"))
-/// ```
-/// 
-/// ## C String Format
-/// 
-/// C-style strings are byte arrays where:
-/// - Each character is represented as a single byte
-/// - The string is terminated with a null byte (`\x00`)
-/// - No length information is stored (length determined by null terminator)
-/// - Compatible with standard C library string functions
-/// 
-/// ## Error Handling
-/// 
-/// - `from_cstr()` will abort if the input is not properly null-terminated
-/// - `to_cstr()` always produces valid null-terminated output
-/// - Functions expect valid UTF-8 input for proper character conversion
-/// 
-/// ## Platform Considerations
-/// 
-/// - **ASCII/UTF-8**: This module handles single-byte character encodings
-/// - **Windows**: For wide character strings (UTF-16), use the `wstr` module instead
-/// - **C interop**: Perfect for POSIX APIs and most Unix/Linux C functions
+/// Helpers for converting MoonBit strings to and from C `char*` buffers.
+///
+/// The C side is treated as null-terminated UTF-8. These helpers are meant for
+/// ABI boundaries where APIs exchange borrowed or owned `char*` values.
 
 ///|
-/// Converts a null-terminated byte array to a `String`.
-/// 
-/// This function takes a C-style null-terminated byte array and converts it
-/// to a MoonBit `String`. It validates that the input is properly null-terminated
-/// and removes the terminating null byte during conversion.
-/// 
-/// The function performs the following operations:
-/// 1. Validates that the last byte is a null terminator (`\x00`)
-/// 2. Removes the null terminator from the byte array
-/// 3. Converts each byte to its corresponding character
-/// 4. Constructs a MoonBit `String` from the character array
-/// 
-/// ## Parameters
-/// 
-/// - `b`: A byte array that must be null-terminated (ending with `\x00`)
-/// 
-/// ## Returns
-/// 
-/// A `String` representation of the byte array, excluding the null terminator
-/// 
-/// ## Example
-/// 
+/// Decode a null-terminated UTF-8 buffer into a MoonBit `String`.
+///
+/// `from_cstr` requires a trailing `\x00`, removes that terminator, and then
+/// decodes the remaining bytes as UTF-8. Invalid byte sequences are replaced
+/// with the Unicode replacement character so callers can safely inspect or log
+/// malformed input that came from native code.
+///
+/// # Parameters
+///
+/// - `b`: A C-style byte buffer that must end with `\x00`
+///
+/// # Returns
+///
+/// The decoded string without the trailing null byte.
+///
+/// # Panics
+///
+/// Aborts if `b` is empty or does not end with `\x00`.
+///
+/// # Example
+///
 /// ```moonbit nocheck
-/// // Basic conversion
-/// let c_str = b"Hello, world!\x00"
-/// let moonbit_str = @ffi.from_cstr(c_str)
-/// assert_eq(moonbit_str, "Hello, world!")
-///
-/// // UTF-8 text conversion
-/// let utf8_c_str = b"Caf\xc3\xa9\x00"  // "Café" in UTF-8 with null terminator
-/// let utf8_str = @ffi.from_cstr(utf8_c_str)
-/// assert_eq(utf8_str, "Café")
-///
-/// // Empty string conversion
-/// let empty_c_str = b"\x00"
-/// let empty_str = @ffi.from_cstr(empty_c_str)
-/// assert_eq(empty_str, "")
+/// let raw = @ffi.to_cstr("hello")
+/// inspect(@ffi.from_cstr(raw), content="hello")
 /// ```
-/// 
-/// ## Safety
-/// 
-/// - **Validation**: The function aborts with an error message if the input is not null-terminated
-/// - **Memory safety**: No buffer overflows as the function respects byte array boundaries
-/// - **Character encoding**: Assumes valid UTF-8 byte sequences for proper character conversion
-/// 
-/// ## Error Conditions
-/// 
-/// The function will abort execution if:
-/// - The input byte array is empty
-/// - The last byte is not `\x00` (null terminator)
-/// - The input is not a valid null-terminated C string
 pub fn from_cstr(b : Bytes) -> String {
-  if b[b.length() - 1] != 0x00 {
+  if b.length() == 0 || b[b.length() - 1] != 0x00 {
     abort("expected null-terminated byte strings")
   }
-  let b = b.to_array()
-  let _ = b.pop()
-  return b.map(fn(c) { c.to_char() }) |> String::from_array
+  let decoder = @encoding.decoder(UTF8)
+  decoder.decode_lossy(b[0:b.length() - 1])
 }
 
 ///|
-/// Converts a `String` to a C-style null-terminated byte array.
-/// 
-/// This function takes a MoonBit `String` and converts it to a null-terminated
-/// byte array suitable for passing to C functions via FFI. It appends a null
-/// terminator (`\x00`) to ensure C compatibility.
-/// 
-/// The function performs the following operations:
-/// 1. Converts the string to a character array
-/// 2. Appends a null character (`\u{0000}`) to the array
-/// 3. Converts each character to its byte representation
-/// 4. Returns the resulting byte array
-/// 
-/// ## Parameters
-/// 
-/// - `s`: A `String` that will be converted to a null-terminated byte array
-/// 
-/// ## Returns
-/// 
-/// A `Bytes` object containing the null-terminated byte representation of the string.
-/// The returned bytes are suitable for passing to C functions that expect C-style strings.
-/// 
-/// ## Example
-/// 
+/// Encode a MoonBit `String` as a null-terminated UTF-8 buffer.
+///
+/// This is the companion to `from_cstr`. The returned `Bytes` value is suitable
+/// for passing to C APIs that expect UTF-8 `char*` input terminated by a single
+/// zero byte.
+///
+/// # Parameters
+///
+/// - `s`: The MoonBit string to encode
+///
+/// # Returns
+///
+/// UTF-8 bytes for `s` followed by a trailing `\x00`.
+///
+/// # Example
+///
 /// ```moonbit nocheck
-/// // Basic conversion
-/// let moonbit_str = "Hello, world!"
-/// let c_str = @ffi.to_cstr(moonbit_str)
-/// assert_eq(c_str, b"Hello, world!\x00")
-///
-/// // Empty string conversion
-/// let empty_str = ""
-/// let empty_c_str = @ffi.to_cstr(empty_str)
-/// assert_eq(empty_c_str, b"\x00")
-///
-/// // UTF-8 text conversion
-/// let utf8_str = "Café"
-/// let utf8_c_str = @ffi.to_cstr(utf8_str)
-/// assert_eq(utf8_c_str, b"Caf\xc3\xa9\x00")
-///
-/// // Using with FFI functions
-/// // extern "C" fn printf(format : Bytes, ...) -> Int = "printf"
-/// // let message = "Hello from MoonBit!"
-/// // let result = printf(@ffi.to_cstr("%s\n"), @ffi.to_cstr(message))
+/// inspect(@ffi.to_cstr("ffi"), content=b"ffi\x00")
 /// ```
-/// 
-/// ## Memory Management
-/// 
-/// - **Safe allocation**: The function creates a new byte array, no memory leaks
-/// - **Automatic sizing**: Automatically calculates the correct buffer size
-/// - **Null termination**: Always ensures proper null termination for C compatibility
-/// 
-/// ## Character Encoding
-/// 
-/// - **UTF-8 compatible**: Properly handles UTF-8 encoded characters
-/// - **Byte-by-byte**: Each character is converted to its byte representation
-/// - **C standard**: Results are compatible with standard C string functions
-/// 
-/// ## Use Cases
-/// 
-/// - **FFI calls**: Passing strings to C functions that expect `char*` parameters
-/// - **File operations**: Working with C file APIs that use string paths
-/// - **System calls**: Interfacing with POSIX APIs that require C strings
-/// - **Library integration**: Calling third-party C libraries from MoonBit
 pub fn to_cstr(s : String) -> Bytes {
-  let s = s.to_array()
-  s.push('\u{0000}')
-  return s.map(fn(c) { c.to_int().to_byte() }) |> Bytes::from_array
+  @encoding.encode(UTF8, s + "\u{0000}")
 }

--- a/src/ffi_test.mbt
+++ b/src/ffi_test.mbt
@@ -1,0 +1,33 @@
+///|
+test "cstr round trip utf8" {
+  let input = "Hello, 世界"
+  assert_eq(@ffi.from_cstr(@ffi.to_cstr(input)), input)
+}
+
+///|
+test "to_cstr appends a trailing nul" {
+  assert_eq(@ffi.to_cstr("ffi"), b"ffi\x00")
+  assert_eq(@ffi.to_cstr(""), b"\x00")
+}
+
+///|
+test "panic from_cstr requires terminator" {
+  @ffi.from_cstr(b"ffi") |> ignore
+}
+
+///|
+test "wstr round trip unicode" {
+  let input = "Hello, 世界 😀"
+  assert_eq(@ffi.from_wstr_lossy(@ffi.to_wstr(input)), input)
+}
+
+///|
+test "to_wstr appends a trailing wide nul" {
+  assert_eq(@ffi.to_wstr("Hi"), b"\x48\x00\x69\x00\x00\x00")
+  assert_eq(@ffi.to_wstr(""), b"\x00\x00")
+}
+
+///|
+test "panic from_wstr_lossy requires terminator" {
+  @ffi.from_wstr_lossy(b"\x00") |> ignore
+}

--- a/src/wstr.mbt
+++ b/src/wstr.mbt
@@ -1,238 +1,62 @@
 ///|
-/// # Windows Wide String (UTF-16) Conversion Module
-/// 
-/// This module provides functions for working with Windows wide strings (UTF-16 encoded)
-/// which are commonly used in Windows API functions. Windows represents Unicode characters
-/// using UTF-16 encoding, where each character is encoded as a 16-bit value.
-/// 
-/// UTF-16 characters are called **wide** characters, to distinguish them from
-/// 8-bit ANSI characters used in traditional C strings.
-/// 
-/// ## Features
-/// 
-/// - **UTF-16 support**: Full Unicode support via UTF-16 encoding
-/// - **Windows API compatibility**: Designed for Windows API functions ending in 'W'
-/// - **Null termination**: Proper null termination for C compatibility
-/// - **Lossy conversion**: Safe conversion that handles invalid UTF-16 sequences
-/// - **Bidirectional**: Convert from and to wide strings
-/// 
-/// ## Basic Usage
-/// 
-/// ```moonbit
-/// // Convert MoonBit string to Windows wide string (UTF-16)
-/// let moonbit_str = "Hello, 世界!"
-/// let wide_str = @ffi.to_wstr(moonbit_str)
-/// // wide_str contains UTF-16 bytes with null termination
-/// 
-/// // Convert wide string back to MoonBit string
-/// let recovered_str = @ffi.from_wstr_lossy(wide_str)
-/// // recovered_str equals "Hello, 世界!"
-/// 
-/// // Use with Windows API functions
-/// // extern "C" fn MessageBoxW(hWnd : Int, lpText : Bytes, lpCaption : Bytes, uType : Int) -> Int = "MessageBoxW"
-/// // let result = MessageBoxW(0, 
-/// //   @ffi.to_wstr("Hello from MoonBit!"), 
-/// //   @ffi.to_wstr("Title"), 
-/// //   0)
-/// ```
-/// 
-/// ## UTF-16 Encoding Details
-/// 
-/// UTF-16 encoding characteristics:
-/// - **Basic characters**: Most characters encoded as single 16-bit units
-/// - **Surrogate pairs**: Characters outside BMP use two 16-bit units
-/// - **Byte order**: Uses system byte order (little-endian on x86/x64)
-/// - **Null termination**: Terminated with two zero bytes (`\x00\x00`)
-/// 
-/// ## Windows API Integration
-/// 
-/// This module is specifically designed for Windows APIs that use wide strings:
-/// - Functions ending in 'W' (wide) rather than 'A' (ANSI)
-/// - Registry functions, file operations, UI functions
-/// - Modern Windows APIs that require Unicode support
-/// 
-/// ## Error Handling
-/// 
-/// - **Lossy conversion**: `from_wstr_lossy()` handles invalid UTF-16 gracefully
-/// - **Validation**: Functions validate proper null termination
-/// - **Encoding safety**: Uses MoonBit's built-in UTF-16 encoder/decoder
-/// 
-/// ## Platform Considerations
-/// 
-/// - **Windows specific**: Primarily useful for Windows development
-/// - **Cross-platform**: Can be used on other platforms for UTF-16 data
-/// - **Performance**: Efficient conversion using native encoding libraries
+/// Helpers for converting MoonBit strings to and from Windows wide strings.
+///
+/// Wide strings in this package are null-terminated UTF-16LE byte buffers, the
+/// form used by most Win32 APIs that end with `W`.
 
 ///|
-/// Converts a null-terminated UTF-16 byte array to a `String`.
-/// 
-/// This function handles UTF-16 encoded wide strings commonly used on Windows.
-/// It expects the byte array to be null-terminated (ending with two zero bytes)
-/// and uses lossy conversion to handle any invalid UTF-16 sequences gracefully.
-/// 
-/// The function performs the following operations:
-/// 1. Validates that the input is properly null-terminated (last two bytes are zero)
-/// 2. Removes the null termination bytes
-/// 3. Uses the UTF-16 decoder to convert bytes to a string
-/// 4. Applies lossy conversion to handle invalid sequences
-/// 
-/// ## Parameters
-/// 
-/// - `b`: A byte array containing UTF-16 encoded data, expected to be null-terminated
-///   with two zero bytes (`\x00\x00`)
-/// 
-/// ## Returns
-/// 
-/// A `String` representation of the UTF-16 data, excluding the null terminator.
-/// Invalid UTF-16 sequences are replaced with the Unicode replacement character (�).
-/// 
-/// ## Example
-/// 
+/// Decode a null-terminated UTF-16LE buffer into a MoonBit `String`.
+///
+/// The trailing wide null (`\x00\x00`) is required and removed before decoding.
+/// Invalid UTF-16 sequences are replaced with the Unicode replacement
+/// character, which keeps the function safe for lossy logging and interop code.
+///
+/// # Parameters
+///
+/// - `b`: A UTF-16LE byte buffer that must end with `\x00\x00`
+///
+/// # Returns
+///
+/// The decoded string without the trailing wide null.
+///
+/// # Panics
+///
+/// Aborts if `b` is shorter than two bytes or is missing the trailing wide
+/// null terminator.
+///
+/// # Example
+///
 /// ```moonbit nocheck
-/// // Basic ASCII conversion
-/// let wide_hello = b"\x48\x00\x65\x00\x6c\x00\x6c\x00\x6f\x00\x00\x00"
-/// let str_hello = @ffi.from_wstr_lossy(wide_hello)
-/// assert_eq(str_hello, "Hello")
-///
-/// // Unicode characters (Chinese text)
-/// let wide_chinese = b"\x16\x4e\x96\x75\x00\x00"  // "世界" in UTF-16LE
-/// let str_chinese = @ffi.from_wstr_lossy(wide_chinese)
-/// assert_eq(str_chinese, "世界")
-///
-/// // Empty string
-/// let empty_wide = b"\x00\x00"
-/// let empty_str = @ffi.from_wstr_lossy(empty_wide)
-/// assert_eq(empty_str, "")
-///
-/// // Mixed content
-/// let mixed = b"\x48\x00\x65\x00\x6c\x00\x6c\x00\x6f\x00\x2c\x00\x20\x00\x16\x4e\x96\x75\x21\x00\x00\x00"
-/// let mixed_str = @ffi.from_wstr_lossy(mixed)
-/// assert_eq(mixed_str, "Hello, 世界!")
+/// let raw = @ffi.to_wstr("Hello")
+/// inspect(@ffi.from_wstr_lossy(raw), content="Hello")
 /// ```
-/// 
-/// ## Safety and Error Handling
-/// 
-/// - **Null termination check**: Aborts if the input is not properly null-terminated
-/// - **Lossy conversion**: Invalid UTF-16 sequences are replaced rather than causing errors
-/// - **Memory safety**: Respects byte array boundaries and validates input length
-/// - **Graceful degradation**: Continues processing even with some invalid data
-/// 
-/// ## UTF-16 Specifics
-/// 
-/// - **Byte order**: Assumes system byte order (little-endian on Windows x86/x64)
-/// - **Surrogate pairs**: Properly handles characters requiring surrogate pairs
-/// - **BOM handling**: Does not expect or process Byte Order Mark (BOM)
-/// - **Alignment**: Input should be properly aligned for 16-bit values
-/// 
-/// ## Error Conditions
-/// 
-/// The function will abort execution if:
-/// - The input byte array has fewer than 2 bytes
-/// - The last two bytes are not both `\x00` (proper null termination)
-/// - The input is not a valid null-terminated wide string
 pub fn from_wstr_lossy(b : Bytes) -> String {
   if b.length() < 2 || b[b.length() - 2] != 0x00 || b[b.length() - 1] != 0x00 {
     abort("expected null-terminated wide strings")
   }
   let decoder = @encoding.decoder(UTF16)
-  return decoder.decode_lossy(b[0:b.length() - 2])
+  decoder.decode_lossy(b[0:b.length() - 2])
 }
 
 ///|
-/// Converts a `String` to a null-terminated UTF-16 byte array.
-/// 
-/// This function converts a MoonBit string to UTF-16 encoding with null termination,
-/// which is the format commonly used for Windows wide string APIs. The resulting
-/// byte array can be passed directly to Windows API functions that expect wide strings.
-/// 
-/// The function performs the following operations:
-/// 1. Appends a null terminator to the input string
-/// 2. Uses the UTF-16 encoder to convert the string to bytes
-/// 3. Returns the encoded byte array with proper null termination
-/// 
-/// ## Parameters
-/// 
-/// - `s`: A `String` that will be converted to a null-terminated UTF-16 byte array
-/// 
-/// ## Returns
-/// 
-/// A `Bytes` object containing the UTF-16 encoded representation with null termination.
-/// The result is suitable for passing to Windows API functions that expect wide strings.
-/// 
-/// ## Example
-/// 
+/// Encode a MoonBit `String` as a null-terminated UTF-16LE buffer.
+///
+/// Use this when calling Windows APIs that accept `wchar_t*` or `LPCWSTR`
+/// values. The returned bytes always end with a wide null terminator.
+///
+/// # Parameters
+///
+/// - `s`: The MoonBit string to encode
+///
+/// # Returns
+///
+/// UTF-16LE bytes for `s` followed by `\x00\x00`.
+///
+/// # Example
+///
 /// ```moonbit nocheck
-/// // Basic ASCII conversion
-/// let hello_str = "Hello"
-/// let hello_wide = @ffi.to_wstr(hello_str)
-/// assert_eq(hello_wide, b"\x48\x00\x65\x00\x6c\x00\x6c\x00\x6f\x00\x00\x00")
-///
-/// // Unicode characters (Chinese text)
-/// let chinese_str = "世界"
-/// let chinese_wide = @ffi.to_wstr(chinese_str)
-/// assert_eq(chinese_wide, b"\x16\x4e\x96\x75\x00\x00")
-///
-/// // Empty string
-/// let empty_str = ""
-/// let empty_wide = @ffi.to_wstr(empty_str)
-/// assert_eq(empty_wide, b"\x00\x00")
-///
-/// // Mixed content with emojis
-/// let mixed_str = "Hello, 世界! 🌍"
-/// let mixed_wide = @ffi.to_wstr(mixed_str)
-/// assert_eq(mixed_wide, b"\x48\x00\x65\x00\x6c\x00\x6c\x00\x6f\x00\x2c\x00\x20\x00\x16\x4e\x96\x75\x21\x00\x20\xd8\x3d\xde\x0d\x00\x00")
-///
-/// // Using with Windows API
-/// // extern "C" fn CreateFileW(
-/// //   lpFileName : Bytes,
-/// //   dwDesiredAccess : Int,
-/// //   dwShareMode : Int,
-/// //   lpSecurityAttributes : Int64,
-/// //   dwCreationDisposition : Int,
-/// //   dwFlagsAndAttributes : Int,
-/// //   hTemplateFile : Int64
-/// // ) -> Int64 = "CreateFileW"
-/// // 
-/// // let file_handle = CreateFileW(
-/// //   @ffi.to_wstr("C:\\path\\to\\file.txt"),
-/// //   0x80000000,  // GENERIC_READ
-/// //   1,           // FILE_SHARE_READ
-/// //   0,           // No security attributes
-/// //   3,           // OPEN_EXISTING
-/// //   0x80,        // FILE_ATTRIBUTE_NORMAL
-/// //   0            // No template file
-/// // )
+/// inspect(@ffi.to_wstr("Hi"), content=b"\x48\x00\x69\x00\x00\x00")
 /// ```
-/// 
-/// ## UTF-16 Encoding Details
-/// 
-/// - **Character representation**: Each character encoded as one or two 16-bit units
-/// - **Byte order**: Uses system byte order (little-endian on Windows x86/x64)
-/// - **Surrogate pairs**: Automatically handles characters outside the Basic Multilingual Plane
-/// - **Null termination**: Always appends two zero bytes for C API compatibility
-/// 
-/// ## Memory and Performance
-/// 
-/// - **Memory allocation**: Creates a new byte array with proper sizing
-/// - **Encoding efficiency**: Uses optimized UTF-16 encoding implementation
-/// - **Size calculation**: Automatically determines correct buffer size
-/// - **No leaks**: Memory management handled by MoonBit runtime
-/// 
-/// ## Use Cases
-/// 
-/// - **Windows API calls**: Perfect for functions ending in 'W' (wide character versions)
-/// - **File operations**: Windows file paths and names
-/// - **Registry operations**: Windows registry keys and values
-/// - **UI operations**: Window titles, menu items, dialog text
-/// - **COM interfaces**: Component Object Model string parameters
-/// 
-/// ## Character Support
-/// 
-/// - **ASCII**: All ASCII characters (0-127) encoded efficiently
-/// - **Latin scripts**: Full support for European languages
-/// - **CJK characters**: Chinese, Japanese, Korean character support
-/// - **Emojis**: Modern Unicode emojis and symbols
-/// - **Mathematical symbols**: Unicode mathematical and technical symbols
 pub fn to_wstr(s : String) -> Bytes {
-  return @encoding.encode(UTF16, s + "\u{0000}")
+  @encoding.encode(UTF16, s + "\u{0000}")
 }


### PR DESCRIPTION
## Summary
- split the repository README from the package README and point module metadata at README.mbt.md
- tighten public API docs, refine UTF-8/UTF-16 string conversion helpers, and add black-box coverage tests
- upload native coverage reports from Linux, macOS, and Windows to Codecov and add the supporting config

## Validation
- moon check --target all --deny-warn
- moon test --target all
- moon test --target native --enable-coverage
- moon coverage analyze -p justjavac/ffi -- -f summary