### PR TITLE
chore: release 0.2.4

### DIFF
--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "justjavac/ffi"
 
-version = "0.2.3"
+version = "0.2.4"
 
 import {
   "moonbitlang/x@0.4.46",


### PR DESCRIPTION
Release justjavac/ffi 0.2.4 after dependency and CI updates.